### PR TITLE
Fix possible typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/soh335/shukujitsu)](https://pkg.go.dev/github.com/soh335/shukujitsu) ![test](https://github.com/soh335/shukujitsu/workflows/test/badge.svg)
 
-shukujitsu datermin japanese holiday.
+shukujitsu determines japanese holiday.
 Holidays are collected from https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv
 
 When csv is updated, you can updated as follow command.

--- a/shukujitsu.go
+++ b/shukujitsu.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// IsShukujitsu datermin shukujitsu.
+// IsShukujitsu determines shukujitsu.
 // This function don't care timezone of arguments time.
 // So you need to care your timezone.
 func IsShukujitsu(t time.Time) bool {


### PR DESCRIPTION
Hi, I found a possible typo.

I replaced them with the following one-liner.

```
$ rg datermin --files-with-matches | xargs -I {} sed -i -e 's/datermin/determines/' {}
```