### PR TITLE
Add cli shukujitsu command.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: release
+
+on:
+  push:
+    branches:
+      - "!**/*"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v1
+        with:
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 syukujitsu.csv
+dist/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,26 @@
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    main: ./cmd/shukujitsu/main.go
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+archives:
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/cli.go
+++ b/cli.go
@@ -1,0 +1,45 @@
+package shukujitsu
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// CLIOption represents an option for CLI.
+type CLIOption struct {
+	Quiet      bool
+	Date       string
+	DateFormat string
+	Writer     io.Writer
+}
+
+// RunCLI runs shukujitsu CLI.
+// return values
+// 0 : is Shukujitsu
+// 1 : is not Shukujitsu
+// 2 : parse error of -d (date)
+func RunCLI(opt *CLIOption) int {
+	var (
+		now time.Time
+		err error
+	)
+	if opt.Date == "" {
+		now = time.Now()
+	} else {
+		now, err = time.Parse(opt.DateFormat, opt.Date)
+		if err != nil {
+			fmt.Fprintln(opt.Writer, err)
+			return 2
+		}
+	}
+
+	name, ok := dates[now.Format("2006/1/2")]
+	if !opt.Quiet {
+		fmt.Fprintln(opt.Writer, now.Format(opt.DateFormat), name)
+	}
+	if !ok {
+		return 1
+	}
+	return 0
+}

--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,76 @@
+package shukujitsu
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+var cliTestCases = []struct {
+	quiet  bool
+	date   string
+	output string
+	code   int
+}{
+	{
+		quiet:  false,
+		date:   "2021-01-01",
+		output: "2021-01-01 元日",
+		code:   0,
+	},
+	{
+		quiet:  false,
+		date:   "2021-01-02",
+		output: "2021-01-02 ",
+		code:   1,
+	},
+	{
+		quiet:  false,
+		date:   "2021-01-0x",
+		output: `parsing time "2021-01-0x" as "2006-01-02": cannot parse "0x" as "02"`,
+		code:   2,
+	},
+	{
+		quiet:  true,
+		date:   "2021-01-01",
+		output: "",
+		code:   0,
+	},
+	{
+		quiet:  true,
+		date:   "2021-01-02",
+		output: "",
+		code:   1,
+	},
+	{
+		quiet:  true,
+		date:   "2021-01-0x",
+		output: `parsing time "2021-01-0x" as "2006-01-02": cannot parse "0x" as "02"`,
+		code:   2,
+	},
+}
+
+func TestCLI(t *testing.T) {
+	stdout := os.Stdout
+	defer func() {
+		os.Stdout = stdout
+	}()
+	for _, c := range cliTestCases {
+		var b []byte
+		buf := bytes.NewBuffer(b)
+		code := RunCLI(&CLIOption{
+			Quiet:      c.quiet,
+			Date:       c.date,
+			DateFormat: "2006-01-02",
+			Writer:     buf,
+		})
+		if code != c.code {
+			t.Errorf("unexpected code %d %v", code, c)
+		}
+		output := strings.TrimRight(buf.String(), "\n")
+		if output != c.output {
+			t.Errorf("unexpected output %s %v", output, c)
+		}
+	}
+}

--- a/cmd/shukujitsu/main.go
+++ b/cmd/shukujitsu/main.go
@@ -2,24 +2,32 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/soh335/shukujitsu"
 )
 
 var (
-	quiet      bool
-	date       string
-	dateFormat = "2006-01-02"
+	quiet       bool
+	date        string
+	dateFormat  = "2006-01-02"
+	showVersion bool
+	version     = "current"
 )
 
 func init() {
 	flag.BoolVar(&quiet, "quiet", false, "quiet")
 	flag.StringVar(&date, "date", "", "date (format "+dateFormat+")")
+	flag.BoolVar(&showVersion, "version", false, "show version")
 }
 
 func main() {
 	flag.Parse()
+	if showVersion {
+		fmt.Println("shukujitsu", version)
+		return
+	}
 	code := shukujitsu.RunCLI(&shukujitsu.CLIOption{
 		Quiet:      quiet,
 		Date:       date,

--- a/cmd/shukujitsu/main.go
+++ b/cmd/shukujitsu/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/soh335/shukujitsu"
+)
+
+var (
+	quiet      bool
+	date       string
+	dateFormat = "2006-01-02"
+)
+
+func init() {
+	flag.BoolVar(&quiet, "quiet", false, "quiet")
+	flag.StringVar(&date, "date", "", "date (format "+dateFormat+")")
+}
+
+func main() {
+	flag.Parse()
+	code := shukujitsu.RunCLI(&shukujitsu.CLIOption{
+		Quiet:      quiet,
+		Date:       date,
+		DateFormat: dateFormat,
+		Writer:     os.Stdout,
+	})
+	os.Exit(code)
+}


### PR DESCRIPTION
Hi.
I add a cli command `shukujitsu`.

My motivation is use this command in crontab as below.
```
0 0 * * Mon-Fri shukujitsu || command-for-weekday
```

shukujitsu cli exits with 0 at public holiday, therefore the `command-for-weekday` will not run at public holiday even if the day is weekday.

shukujitsu cli exits with 1 at not public holiday. `command-for-weekday` runs weekday normally. 

Usage:
```console
$ shukujitsu -h
Usage of shukujitsu:
  -date string
        date (format 2006-01-02)
  -quiet
        quiet
```