### PR TITLE
ci: fix the release failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod download
@@ -17,7 +18,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
The release failed due to the error of GoReleaser.

https://github.com/soh335/shukujitsu/actions/runs/13109123190/job/36569027577

```
/opt/hostedtoolcache/goreleaser-action/2.6.1/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.6.1/x64/goreleaser' failed with exit code 1
```

No asset was released.

https://github.com/soh335/shukujitsu/releases/tag/v0.0.8

<img width="237" alt="image" src="https://github.com/user-attachments/assets/7c2f0b80-6353-48ce-8795-a8b99022a43d" />

This pull request resolves the error.

https://goreleaser.com/deprecations/#-rm-dist
https://goreleaser.com/deprecations/#snapshotname_template
https://goreleaser.com/blog/goreleaser-v2/?h=#upgrading

> It should only warn you about the version header in the configuration file, which you can fix by adding version: 2 to it.